### PR TITLE
Configuração .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+/node_modules
+/public/hot
+/public/storage
+/storage/*.key
+/vendor
+.phpunit.result.cache
+Homestead.json
+Homestead.yaml
+npm-debug.log
+yarn-error.log


### PR DESCRIPTION
Configuração do arquivo .gitignore para não carregar pastas e arquivos nativos do laravel.
(Posteriormente será descrito no readme.md as instruções para a aquisição destes arquivos e diretórios)